### PR TITLE
Fix no error message when creating duplicate Quick resources

### DIFF
--- a/manager/src/main/java/com/bakdata/quick/manager/application/KubernetesApplicationService.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/application/KubernetesApplicationService.java
@@ -79,7 +79,7 @@ public class KubernetesApplicationService implements ApplicationService {
             .map(serviceExists -> {
                 final ApplicationResources applicationResources = this.loader.forDeletion(deploymentName);
                 if (!serviceExists) {
-                    return new ApplicationResources(applicationResources.getDeployment(), Optional.empty());
+                    return new ApplicationResources(name, applicationResources.getDeployment(), Optional.empty());
                 }
                 return applicationResources;
             })

--- a/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoader.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoader.java
@@ -77,7 +77,8 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
             Objects.requireNonNullElse(appCreationData.getReplicas(), this.deploymentConfig.getDefaultReplicas());
         final ImageConfig config = ImageConfig.of(appCreationData.getRegistry(), appCreationData.getImageName(),
             replicas, appCreationData.getTag());
-        final String deploymentName = getDeploymentName(appCreationData.getName());
+        final String applicationName = appCreationData.getName();
+        final String deploymentName = getDeploymentName(applicationName);
         final Map<String, String> arguments = Objects.requireNonNullElse(appCreationData.getArguments(), Map.of());
         final List<String> listArgs = CliArgHandler.convertArgs(arguments, this.kafkaConfig);
 
@@ -88,9 +89,9 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
         if (appCreationData.getPort() != null) {
             final ApplicationService service =
                 new ApplicationService(this.createApplicationService(deploymentName, appCreationData.getPort()));
-            return new ApplicationResources(deployment, Optional.of(service));
+            return new ApplicationResources(applicationName, deployment, Optional.of(service));
         }
-        return new ApplicationResources(deployment, Optional.empty());
+        return new ApplicationResources(applicationName, deployment, Optional.empty());
     }
 
     /**
@@ -109,7 +110,7 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
         final ApplicationService service =
             new ApplicationService(KubernetesResources.forDeletion(Service.class, name));
 
-        return new ApplicationResources(deployment, Optional.of(service));
+        return new ApplicationResources(name, deployment, Optional.of(service));
     }
 
     /**

--- a/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResources.java
@@ -32,12 +32,15 @@ import lombok.Getter;
  */
 public class ApplicationResources implements QuickResources {
 
+    private final String name;
     @Getter
     private final ApplicationDeployment deployment;
     private final Optional<ApplicationService> service;
 
-    public ApplicationResources(final ApplicationDeployment deployment,
-        final Optional<ApplicationService> service) {
+    public ApplicationResources(final String name,
+                                final ApplicationDeployment deployment,
+                                final Optional<ApplicationService> service) {
+        this.name = name;
         this.deployment = deployment;
         this.service = service;
     }
@@ -46,5 +49,10 @@ public class ApplicationResources implements QuickResources {
     public List<QuickResource> listResources() {
         return this.service.map(applicationService -> List.of(this.deployment, applicationService))
             .orElseGet(() -> List.of(this.deployment));
+    }
+
+    @Override
+    public String getResourcesName() {
+        return this.name;
     }
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/gateway/KubernetesGatewayService.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/gateway/KubernetesGatewayService.java
@@ -85,7 +85,6 @@ public class KubernetesGatewayService implements GatewayService {
 
     @Override
     public Completable createGateway(final GatewayCreationData gatewayCreationData) {
-
         return Single.fromCallable(() -> this.loader.forCreation(gatewayCreationData, ResourcePrefix.GATEWAY))
             .flatMapCompletable(this.kubernetesManagerClient::deploy);
     }

--- a/manager/src/main/java/com/bakdata/quick/manager/gateway/KubernetesGatewayService.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/gateway/KubernetesGatewayService.java
@@ -85,6 +85,7 @@ public class KubernetesGatewayService implements GatewayService {
 
     @Override
     public Completable createGateway(final GatewayCreationData gatewayCreationData) {
+
         return Single.fromCallable(() -> this.loader.forCreation(gatewayCreationData, ResourcePrefix.GATEWAY))
             .flatMapCompletable(this.kubernetesManagerClient::deploy);
     }

--- a/manager/src/main/java/com/bakdata/quick/manager/gateway/resource/GatewayResourceLoader.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/gateway/resource/GatewayResourceLoader.java
@@ -105,7 +105,8 @@ public class GatewayResourceLoader implements ResourceLoader<GatewayResources, G
 
         final String dockerRegistry = this.deploymentConfig.getDockerRegistry();
         final ImageConfig imageConfig = ImageConfig.of(dockerRegistry, GATEWAY_IMAGE, imageReplicas, imageTag);
-        final String resourceName = getResourceName(gatewayCreationData.getName());
+        final String gatewayName = gatewayCreationData.getName();
+        final String resourceName = getResourceName(gatewayName);
         final boolean hasFixedTag = gatewayCreationData.getTag() != null;
 
         final GatewayDeployment deployment = new GatewayDeployment(
@@ -124,7 +125,7 @@ public class GatewayResourceLoader implements ResourceLoader<GatewayResources, G
         final GatewayConfigMap configMap =
             new GatewayConfigMap(this.createGatewayConfigMap(resourceName, gatewayCreationData.getSchema()));
 
-        return new GatewayResources(deployment, service, ingress, middleware, configMap);
+        return new GatewayResources(gatewayName, deployment, service, ingress, middleware, configMap);
     }
 
     /**
@@ -150,7 +151,7 @@ public class GatewayResourceLoader implements ResourceLoader<GatewayResources, G
         final GatewayConfigMap configMap =
             new GatewayConfigMap(KubernetesResources.forDeletion(ConfigMap.class, getConfigMapName(name)));
 
-        return new GatewayResources(deployment, service, ingress, middleware, configMap);
+        return new GatewayResources(name, deployment, service, ingress, middleware, configMap);
     }
 
     /**

--- a/manager/src/main/java/com/bakdata/quick/manager/gateway/resource/GatewayResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/gateway/resource/GatewayResources.java
@@ -45,6 +45,7 @@ public class GatewayResources implements QuickResources {
 
     public static final String GATEWAY_IMAGE = "quick-gateway";
 
+    private final String name;
     private final GatewayDeployment deployment;
     private final GatewayService service;
     private final GatewayIngress ingress;
@@ -60,8 +61,10 @@ public class GatewayResources implements QuickResources {
      * @param middleware        For gateway Middleware resource
      * @param configMap         For gateway ConfigMap resource
      */
-    public GatewayResources(final GatewayDeployment gatewayDeployment, final GatewayService gatewayService,
-        final GatewayIngress gatewayIngress, final GatewayMiddleware middleware, final GatewayConfigMap configMap) {
+    public GatewayResources(final String name, final GatewayDeployment gatewayDeployment,
+                            final GatewayService gatewayService, final GatewayIngress gatewayIngress,
+                            final GatewayMiddleware middleware, final GatewayConfigMap configMap) {
+        this.name = name;
         this.deployment = gatewayDeployment;
         this.service = gatewayService;
         this.ingress = gatewayIngress;
@@ -120,4 +123,11 @@ public class GatewayResources implements QuickResources {
     public List<QuickResource> listResources() {
         return List.of(this.deployment, this.service, this.ingress, this.middleware, this.configMap);
     }
+
+    @Override
+    public String getResourcesName() {
+        return this.name;
+    }
+
+
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/gateway/resource/GatewayResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/gateway/resource/GatewayResources.java
@@ -128,6 +128,4 @@ public class GatewayResources implements QuickResources {
     public String getResourcesName() {
         return this.name;
     }
-
-
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
@@ -90,11 +90,8 @@ public class KubernetesManagerClient {
             if (resourcesMetadata.stream().allMatch(Objects::isNull)) {
                 return this.client.resourceList(resourceList).inNamespace(this.namespace).createOrReplace();
             } else {
-                final String names = resourcesMetadata.stream()
-                        .filter(Objects::nonNull)
-                        .map(singleResourceMetadata -> singleResourceMetadata.getMetadata().getName())
-                        .collect(Collectors.joining(", "));
-                throw new BadArgumentException(String.format("Following resources already exist: %s", names));
+                String resourcesName = quickResources.getResourcesName();
+                throw new BadArgumentException(String.format("Following resources already exist: %s", resourcesName));
             }
         });
     }

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
@@ -36,6 +36,7 @@ import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -76,15 +77,24 @@ public class KubernetesManagerClient {
     }
 
     /**
-     * Deploys all the resources passed in.
+     * Deploys all the resources passed in provided that they have not already been deployed.
      *
      * @param quickResources A quick resources object containing one or many kubernetes resources
-     * @return Completable or throws an exception if fail
+     * @return Completable or throws an exception if specific resources already exist
      */
     public Completable deploy(final QuickResources quickResources) {
         return Completable.fromCallable(() -> {
             final KubernetesList resourceList = getKubernetesList(quickResources);
-            return this.client.resourceList(resourceList).inNamespace(this.namespace).createOrReplace();
+            final List<HasMetadata> resourcesMetadata = this.client.resourceList(resourceList)
+                    .inNamespace(this.namespace).fromServer().get();
+            if (resourcesMetadata.stream().allMatch(Objects::isNull)) {
+                return this.client.resourceList(resourceList).inNamespace(this.namespace).createOrReplace();
+            } else {
+                final String names = resourcesMetadata.stream()
+                        .map(singleResourceMetadata -> singleResourceMetadata.getMetadata().getName())
+                        .collect(Collectors.joining(", "));
+                throw new BadArgumentException(String.format("Following resources already exist: %s", names));
+            }
         });
     }
 

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
@@ -90,8 +90,8 @@ public class KubernetesManagerClient {
             if (resourcesMetadata.stream().allMatch(Objects::isNull)) {
                 return this.client.resourceList(resourceList).inNamespace(this.namespace).createOrReplace();
             } else {
-                String resourcesName = quickResources.getResourcesName();
-                throw new BadArgumentException(String.format("Following resources already exist: %s", resourcesName));
+                final String resourcesName = quickResources.getResourcesName();
+                throw new BadArgumentException(String.format("The resource with the name %s already exists", resourcesName));
             }
         });
     }

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
@@ -77,10 +77,10 @@ public class KubernetesManagerClient {
     }
 
     /**
-     * Deploys all the resources passed in provided that they have not already been deployed.
+     * Deploys all the resources passed in.
      *
      * @param quickResources A quick resources object containing one or many kubernetes resources
-     * @return Completable or throws an exception if specific resources already exist
+     * @return Returns a Completable or throws an exception if specific resources already exist
      */
     public Completable deploy(final QuickResources quickResources) {
         return Completable.fromCallable(() -> {
@@ -91,6 +91,7 @@ public class KubernetesManagerClient {
                 return this.client.resourceList(resourceList).inNamespace(this.namespace).createOrReplace();
             } else {
                 final String names = resourcesMetadata.stream()
+                        .filter(Objects::nonNull)
                         .map(singleResourceMetadata -> singleResourceMetadata.getMetadata().getName())
                         .collect(Collectors.joining(", "));
                 throw new BadArgumentException(String.format("Following resources already exist: %s", names));

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesManagerClient.java
@@ -80,7 +80,7 @@ public class KubernetesManagerClient {
      * Deploys all the resources passed in.
      *
      * @param quickResources A quick resources object containing one or many kubernetes resources
-     * @return Returns a Completable or throws an exception if specific resources already exist
+     * @return Completable or an exception if the specific resources already exist
      */
     public Completable deploy(final QuickResources quickResources) {
         return Completable.fromCallable(() -> {

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/resource/QuickResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/resource/QuickResources.java
@@ -52,8 +52,8 @@ public interface QuickResources {
     }
 
     /**
-     * A method for retrieving the name of resources (without prefix).
-     * @return The name that a user has chosen for a specific type of resources (gateway, mirror, app)
+     * Retrieves the name of resources (without prefix).
+     * @return The name that a user has chosen for a specific type of resources.
      */
     String getResourcesName();
 

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/resource/QuickResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/resource/QuickResources.java
@@ -51,6 +51,10 @@ public interface QuickResources {
         }
     }
 
+    /**
+     * A method for retrieving the name of resources (without prefix).
+     * @return The name that a user has chosen for a specific type of resources (gateway, mirror, app)
+     */
     String getResourcesName();
 
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/resource/QuickResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/resource/QuickResources.java
@@ -50,4 +50,7 @@ public interface QuickResources {
             this.prefix = deploymentPrefix;
         }
     }
+
+    String getResourcesName();
+
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/mirror/resources/MirrorResourceLoader.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/mirror/resources/MirrorResourceLoader.java
@@ -73,7 +73,8 @@ public class MirrorResourceLoader implements ResourceLoader<MirrorResources, Mir
      */
     @Override
     public MirrorResources forCreation(final MirrorCreationData mirrorCreationData, final ResourcePrefix prefix) {
-        final String deploymentName = prefix.getPrefix() + mirrorCreationData.getName();
+        final String mirrorName = mirrorCreationData.getName();
+        final String deploymentName = prefix.getPrefix() + mirrorName;
         final String imageTag =
             Objects.requireNonNullElse(mirrorCreationData.getTag(), this.deploymentConfig.getDefaultImageTag());
         final int imageReplicas =
@@ -91,7 +92,7 @@ public class MirrorResourceLoader implements ResourceLoader<MirrorResources, Mir
 
         final MirrorService service = new MirrorService(this.createMirrorService(deploymentName));
 
-        return new MirrorResources(deployment, service);
+        return new MirrorResources(mirrorName, deployment, service);
     }
 
     /**
@@ -107,7 +108,7 @@ public class MirrorResourceLoader implements ResourceLoader<MirrorResources, Mir
         final MirrorDeployment deployment =
             new MirrorDeployment(KubernetesResources.forDeletion(Deployment.class, name));
         final MirrorService service = new MirrorService(KubernetesResources.forDeletion(Service.class, name));
-        return new MirrorResources(deployment, service);
+        return new MirrorResources(name, deployment, service);
     }
 
     public static String getDeploymentName(final String name) {

--- a/manager/src/main/java/com/bakdata/quick/manager/mirror/resources/MirrorResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/mirror/resources/MirrorResources.java
@@ -31,11 +31,14 @@ import java.util.List;
 public class MirrorResources implements QuickResources {
     public static final String MIRROR_IMAGE = "quick-mirror";
 
+    private final String name;
     private final MirrorDeployment deployment;
     private final MirrorService service;
 
-    public MirrorResources(final MirrorDeployment deployment,
-        final MirrorService service) {
+    public MirrorResources(final String name,
+                           final MirrorDeployment deployment,
+                           final MirrorService service) {
+        this.name = name;
         this.deployment = deployment;
         this.service = service;
     }
@@ -43,5 +46,10 @@ public class MirrorResources implements QuickResources {
     @Override
     public List<QuickResource> listResources() {
         return List.of(this.deployment, this.service);
+    }
+
+    @Override
+    public String getResourcesName() {
+        return this.name;
     }
 }

--- a/manager/src/test/java/com/bakdata/quick/manager/application/ApplicationControllerTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/ApplicationControllerTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.bakdata.quick.common.api.client.ApplicationClient;
-import com.bakdata.quick.common.api.model.manager.creation.ApplicationCreationData;
 import com.bakdata.quick.common.api.model.manager.ApplicationDescription;
+import com.bakdata.quick.common.api.model.manager.creation.ApplicationCreationData;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.uri.UriBuilder;

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -136,7 +136,7 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
     }
 
     @Test
-    void shouldRejectBadApplicationName() {
+    void shouldRejectDuplicateApplicationCreation() {
         final ApplicationCreationData applicationCreationData = new ApplicationCreationData(APP_NAME,
                 DOCKER_REGISTRY,
                 IMAGE_NAME,

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -149,7 +149,7 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
         Optional.ofNullable(firstDeployment.blockingGet()).ifPresent(Assertions::fail);
         final Throwable invalidDeployment = this.service.deployApplication(applicationCreationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessage("Following resources already exist: my-app");
+                .hasMessage("The resource with the name my-app already exists");
     }
 
     private void deployApplication(@Nullable final Integer port, final Map<String, String> arguments) {

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -149,7 +149,7 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
         Optional.ofNullable(firstDeployment.blockingGet()).ifPresent(Assertions::fail);
         final Throwable invalidDeployment = this.service.deployApplication(applicationCreationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("Following resources already exist");
+                .hasMessage("Following resources already exist: my-app");
     }
 
     private void deployApplication(@Nullable final Integer port, final Map<String, String> arguments) {

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.quick.common.api.model.manager.creation.ApplicationCreationData;
 import com.bakdata.quick.common.config.KafkaConfig;
+import com.bakdata.quick.common.exception.BadArgumentException;
 import com.bakdata.quick.manager.application.resources.ApplicationResourceLoader;
 import com.bakdata.quick.manager.k8s.ImageConfig;
 import com.bakdata.quick.manager.k8s.KubernetesResources;
@@ -147,7 +148,8 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
         final Completable firstDeployment = this.service.deployApplication(applicationCreationData);
         Optional.ofNullable(firstDeployment.blockingGet()).ifPresent(Assertions::fail);
         final Throwable invalidDeployment = this.service.deployApplication(applicationCreationData).blockingGet();
-        assertThat(invalidDeployment).isNotNull();
+        assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
+                .hasMessageContaining("Following resources already exist");
     }
 
     private void deployApplication(@Nullable final Integer port, final Map<String, String> arguments) {

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -134,6 +134,22 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
             });
     }
 
+    @Test
+    void shouldRejectBadApplicationName() {
+        final ApplicationCreationData applicationCreationData = new ApplicationCreationData(APP_NAME,
+                DOCKER_REGISTRY,
+                IMAGE_NAME,
+                DEFAULT_IMAGE_TAG,
+                1,
+                DEFAULT_PORT,
+                Map.of());
+
+        final Completable firstDeployment = this.service.deployApplication(applicationCreationData);
+        Optional.ofNullable(firstDeployment.blockingGet()).ifPresent(Assertions::fail);
+        final Throwable invalidDeployment = this.service.deployApplication(applicationCreationData).blockingGet();
+        assertThat(invalidDeployment).isNotNull();
+    }
+
     private void deployApplication(@Nullable final Integer port, final Map<String, String> arguments) {
         final ApplicationCreationData applicationCreationData = new ApplicationCreationData(APP_NAME,
             DOCKER_REGISTRY,

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -149,7 +149,7 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
         Optional.ofNullable(firstDeployment.blockingGet()).ifPresent(Assertions::fail);
         final Throwable invalidDeployment = this.service.deployApplication(applicationCreationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessage("The resource with the name my-app already exists");
+                .hasMessageContaining(String.format("The resource with the name %s already exists", APP_NAME));
     }
 
     private void deployApplication(@Nullable final Integer port, final Map<String, String> arguments) {

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/GatewayControllerTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/GatewayControllerTest.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.when;
 
 import com.bakdata.quick.common.api.client.GatewayClient;
 import com.bakdata.quick.common.api.model.gateway.SchemaData;
-import com.bakdata.quick.common.api.model.manager.creation.GatewayCreationData;
 import com.bakdata.quick.common.api.model.manager.GatewayDescription;
+import com.bakdata.quick.common.api.model.manager.creation.GatewayCreationData;
 import com.bakdata.quick.manager.gateway.GatewayService.SchemaFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -329,7 +329,7 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.gatewayService.createGateway(creationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("Following resources already exist");
+                .hasMessageContaining("Following resources already exist: test-gateway");
     }
 
 

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -323,7 +323,7 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
     }
 
     @Test
-    void shouldRejectBadGatewayName() {
+    void shouldRejectDuplicateGatewayCreation() {
         final GatewayCreationData creationData = new GatewayCreationData(GATEWAY_NAME, 1, null, null);
         final Throwable firstDeployment = this.gatewayService.createGateway(creationData).blockingGet();
         assertThat(firstDeployment).isNull();

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -329,7 +329,7 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.gatewayService.createGateway(creationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("The resource with the name test-gateway already exists");
+                .hasMessageContaining(String.format("The resource with the name %s already exists", GATEWAY_NAME));
     }
 
 

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -22,6 +22,7 @@ import com.bakdata.quick.common.api.client.GatewayClient;
 import com.bakdata.quick.common.api.model.gateway.SchemaData;
 import com.bakdata.quick.common.api.model.manager.GatewayDescription;
 import com.bakdata.quick.common.api.model.manager.creation.GatewayCreationData;
+import com.bakdata.quick.common.exception.BadArgumentException;
 import com.bakdata.quick.manager.gateway.resource.GatewayResourceLoader;
 import com.bakdata.quick.manager.graphql.GraphQLToAvroConverter;
 import com.bakdata.quick.manager.k8s.KubernetesResources;
@@ -327,7 +328,8 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
         final Throwable firstDeployment = this.gatewayService.createGateway(creationData).blockingGet();
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.gatewayService.createGateway(creationData).blockingGet();
-        assertThat(invalidDeployment).isNotNull();
+        assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
+                .hasMessageContaining("Following resources already exist");
     }
 
 

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -329,7 +329,7 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.gatewayService.createGateway(creationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("Following resources already exist: test-gateway");
+                .hasMessageContaining("The resource with the name test-gateway already exists");
     }
 
 

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -321,6 +321,15 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
         assertThat(this.getConfigMaps()).isNullOrEmpty();
     }
 
+    @Test
+    void shouldRejectBadGatewayName() {
+        final GatewayCreationData creationData = new GatewayCreationData(GATEWAY_NAME, 1, null, null);
+        final Throwable firstDeployment = this.gatewayService.createGateway(creationData).blockingGet();
+        assertThat(firstDeployment).isNull();
+        final Throwable invalidDeployment = this.gatewayService.createGateway(creationData).blockingGet();
+        assertThat(invalidDeployment).isNotNull();
+    }
+
 
     private void deleteGatewayResources() {
         this.gatewayService.deleteGateway(GATEWAY_NAME).blockingAwait();

--- a/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
@@ -178,7 +178,7 @@ class KubernetesMirrorServiceTest extends KubernetesTest {
     }
 
     @Test
-    void shouldRejectBadMirrorName() {
+    void shouldRejectDuplicateMirrorCreation() {
         final MirrorCreationData mirrorCreationData = new MirrorCreationData(
                 TOPIC_NAME,
                 TOPIC_NAME,

--- a/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
@@ -189,7 +189,7 @@ class KubernetesMirrorServiceTest extends KubernetesTest {
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("Following resources already exist: test-topic");
+                .hasMessageContaining("The resource with the name test-topic already exists");
     }
 
     private void createMirror(final MirrorCreationData mirrorCreationData) {

--- a/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
@@ -189,7 +189,7 @@ class KubernetesMirrorServiceTest extends KubernetesTest {
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("Following resources already exist");
+                .hasMessageContaining("Following resources already exist: test-topic");
     }
 
     private void createMirror(final MirrorCreationData mirrorCreationData) {

--- a/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
@@ -18,8 +18,10 @@ package com.bakdata.quick.manager.mirror;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.bakdata.quick.common.api.model.manager.creation.MirrorCreationData;
+import com.bakdata.quick.common.exception.BadArgumentException;
 import com.bakdata.quick.manager.k8s.KubernetesResources;
 import com.bakdata.quick.manager.k8s.KubernetesTest;
 import com.bakdata.quick.manager.k8s.resource.QuickResources.ResourcePrefix;
@@ -186,7 +188,8 @@ class KubernetesMirrorServiceTest extends KubernetesTest {
         final Throwable firstDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
-        assertThat(invalidDeployment).isNotNull();
+        assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
+                .hasMessageContaining("Following resources already exist");
     }
 
     private void createMirror(final MirrorCreationData mirrorCreationData) {

--- a/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
@@ -175,6 +175,20 @@ class KubernetesMirrorServiceTest extends KubernetesTest {
             .satisfies(container -> assertThat(container.getArgs()).contains("--input-topics=" + TOPIC_NAME));
     }
 
+    @Test
+    void shouldRejectBadMirrorName() {
+        final MirrorCreationData mirrorCreationData = new MirrorCreationData(
+                TOPIC_NAME,
+                TOPIC_NAME,
+                1,
+                null,
+                null);
+        final Throwable firstDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
+        assertThat(firstDeployment).isNull();
+        final Throwable invalidDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
+        assertThat(invalidDeployment).isNotNull();
+    }
+
     private void createMirror(final MirrorCreationData mirrorCreationData) {
         final Completable completable = this.mirrorService.createMirror(mirrorCreationData);
         Optional.ofNullable(completable.blockingGet()).ifPresent(Assertions::fail);

--- a/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/mirror/KubernetesMirrorServiceTest.java
@@ -189,7 +189,7 @@ class KubernetesMirrorServiceTest extends KubernetesTest {
         assertThat(firstDeployment).isNull();
         final Throwable invalidDeployment = this.mirrorService.createMirror(mirrorCreationData).blockingGet();
         assertThat(invalidDeployment).isInstanceOf(BadArgumentException.class)
-                .hasMessageContaining("The resource with the name test-topic already exists");
+                .hasMessageContaining(String.format("The resource with the name %s already exists", TOPIC_NAME));
     }
 
     private void createMirror(final MirrorCreationData mirrorCreationData) {


### PR DESCRIPTION
Changes made on this branch resolve the issue #15 i.e. when a user tries to create a gateway, an app, or a mirror with a name that already exists, an exception is thrown in order to show that it is not permitted to create these entities with the same name.

The problem has been solved by extending the deploy function in the KubernetesManagerClient class.
Test classes for ApplicationService, MirrorService and GatewayService have been extended.