### PR TITLE
Enable the app deployment from a private container registry 

### DIFF
--- a/common/src/main/java/com/bakdata/quick/common/api/model/manager/creation/ApplicationCreationData.java
+++ b/common/src/main/java/com/bakdata/quick/common/api/model/manager/creation/ApplicationCreationData.java
@@ -34,5 +34,7 @@ public class ApplicationCreationData implements CreationData {
     @Nullable
     Integer port;
     @Nullable
+    String imagePullSecret;
+    @Nullable
     Map<String, String> arguments;
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoader.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoader.java
@@ -122,8 +122,8 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
      * @param resourceConfig memory + cpu requests and limits to use
      */
     private Deployment createAppDeployment(final String name, final List<String> arguments,
-        final ImageConfig imageConfig, final ResourceConfig resourceConfig, @Nullable final Integer port,
-                                           @Nullable final String imagePullSecret) {
+                                           final ImageConfig imageConfig, final ResourceConfig resourceConfig,
+                                           @Nullable final Integer port, @Nullable final String imagePullSecret) {
         final Context root = new Context();
         root.setVariable("name", name);
         root.setVariable("args", arguments);

--- a/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoader.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoader.java
@@ -84,7 +84,7 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
 
         final ApplicationDeployment deployment =
             new ApplicationDeployment(this.createAppDeployment(deploymentName, listArgs, config, this.resourceConfig,
-                appCreationData.getPort()));
+                appCreationData.getPort(),  appCreationData.getImagePullSecret()));
 
         if (appCreationData.getPort() != null) {
             final ApplicationService service =
@@ -122,7 +122,8 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
      * @param resourceConfig memory + cpu requests and limits to use
      */
     private Deployment createAppDeployment(final String name, final List<String> arguments,
-        final ImageConfig imageConfig, final ResourceConfig resourceConfig, @Nullable final Integer port) {
+        final ImageConfig imageConfig, final ResourceConfig resourceConfig, @Nullable final Integer port,
+                                           @Nullable final String imagePullSecret) {
         final Context root = new Context();
         root.setVariable("name", name);
         root.setVariable("args", arguments);
@@ -135,6 +136,7 @@ public class ApplicationResourceLoader implements ResourceLoader<ApplicationReso
         root.setVariable("resourceConfig", resourceConfig);
         root.setVariable("port", port);
         root.setVariable("hasService", !Objects.isNull(port));
+        root.setVariable("imagePullSecret", imagePullSecret);
         return this.kubernetesResources.loadResource(root, "streamsApp/deployment", Deployment.class);
     }
 

--- a/manager/src/main/resources/k8s/templates/streamsApp/deployment.th.yaml
+++ b/manager/src/main/resources/k8s/templates/streamsApp/deployment.th.yaml
@@ -48,5 +48,6 @@ spec:
             requests:
               memory: [(${resourceConfig.memory.request})]
               cpu: [(${resourceConfig.cpu.request})]
-      imagePullSecrets: [# th:if="${imagePullSecret}"]
+      [# th:if="${imagePullSecret}"]
+      imagePullSecrets:
         - name: [(${imagePullSecret})] [/]

--- a/manager/src/main/resources/k8s/templates/streamsApp/deployment.th.yaml
+++ b/manager/src/main/resources/k8s/templates/streamsApp/deployment.th.yaml
@@ -51,3 +51,4 @@ spec:
       [# th:if="${imagePullSecret}"]
       imagePullSecrets:
         - name: [(${imagePullSecret})] [/]
+

--- a/manager/src/main/resources/k8s/templates/streamsApp/deployment.th.yaml
+++ b/manager/src/main/resources/k8s/templates/streamsApp/deployment.th.yaml
@@ -48,3 +48,5 @@ spec:
             requests:
               memory: [(${resourceConfig.memory.request})]
               cpu: [(${resourceConfig.cpu.request})]
+      imagePullSecrets: [# th:if="${imagePullSecret}"]
+        - name: [(${imagePullSecret})] [/]

--- a/manager/src/test/java/com/bakdata/quick/manager/application/ApplicationControllerTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/ApplicationControllerTest.java
@@ -76,7 +76,7 @@ class ApplicationControllerTest {
     @Test
     void shouldDeployApplication() {
         final ApplicationCreationData applicationCreationData =
-            new ApplicationCreationData(NAME, REGISTRY, IMAGE_NAME, TAG, REPLICAS, PORT, ARGS);
+            new ApplicationCreationData(NAME, REGISTRY, IMAGE_NAME, TAG, REPLICAS, PORT, null, ARGS);
 
         when(this.service.deployApplication(applicationCreationData))
             .thenReturn(Completable.complete());
@@ -115,7 +115,7 @@ class ApplicationControllerTest {
     @Test
     void shouldCallDeployApplication() {
         final ApplicationCreationData applicationCreationData =
-            new ApplicationCreationData(NAME, REGISTRY, IMAGE_NAME, TAG, REPLICAS, PORT, ARGS);
+            new ApplicationCreationData(NAME, REGISTRY, IMAGE_NAME, TAG, REPLICAS, PORT, null, ARGS);
 
         when(this.service.deployApplication(applicationCreationData))
             .thenReturn(Completable.complete());

--- a/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/KubernetesApplicationServiceTest.java
@@ -143,6 +143,7 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
                 DEFAULT_IMAGE_TAG,
                 1,
                 DEFAULT_PORT,
+                null,
                 Map.of());
 
         final Completable firstDeployment = this.service.deployApplication(applicationCreationData);
@@ -159,6 +160,7 @@ class KubernetesApplicationServiceTest extends KubernetesTest {
             DEFAULT_IMAGE_TAG,
             1,
             port,
+            null,
             arguments);
 
         final Completable completable = this.service.deployApplication(applicationCreationData);

--- a/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
@@ -27,13 +27,7 @@ import com.bakdata.quick.manager.k8s.KubernetesResources;
 import com.bakdata.quick.manager.k8s.KubernetesTest;
 import com.bakdata.quick.manager.k8s.resource.QuickResources.ResourcePrefix;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.EnvFromSource;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import java.util.List;
@@ -47,6 +41,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
     private static final int DEFAULT_PORT = 8080;
     private static final String NAME = "application-name";
     private static final String DEFAULT_DEPLOYMENT_NAME = ResourcePrefix.APPLICATION.getPrefix() + NAME;
+    private static final String DEFAULT_SECRET = "secret";
 
     private ApplicationResourceLoader loader = null;
     private final KafkaConfig kafkaConfig = new KafkaConfig("bootstrap", "http://dummy:123");
@@ -65,6 +60,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
 
         final ApplicationResources applicationResources =
             this.createApplicationResource(
+                null,
                 null,
                 null,
                 Map.of());
@@ -96,7 +92,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
                     });
 
                 final PodSpec podSpec = deploymentSpec.getTemplate().getSpec();
-
+                assertThat(podSpec.getImagePullSecrets()).isEqualTo(null);
                 assertThat(podSpec.getContainers())
                     .isNotNull()
                     .hasSize(1)
@@ -133,6 +129,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 null,
                 null,
+                null,
                 Map.of("--test", "my-value", "--foo", "bar"));
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
@@ -161,6 +158,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 3,
                 null,
+                null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
@@ -186,6 +184,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 null,
                 null,
+                null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
@@ -208,6 +207,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 null,
                 DEFAULT_PORT,
+                null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
@@ -237,6 +237,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 1,
                 DEFAULT_PORT,
+                null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
@@ -255,6 +256,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 1,
                 DEFAULT_PORT,
+                    null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.SERVICE);
@@ -278,6 +280,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 null,
                 DEFAULT_PORT,
+                null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.SERVICE);
@@ -304,6 +307,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
             this.createApplicationResource(
                 null,
                 DEFAULT_PORT,
+                null,
                 Map.of());
 
         final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
@@ -326,13 +330,36 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
                 });
     }
 
+    @Test
+    void shouldCreateAppDeploymentWithImagePullSecret() {
+        final ApplicationResources applicationResources =
+                this.createApplicationResource(
+                        null,
+                        null,
+                        DEFAULT_SECRET,
+                        Map.of());
+
+        final Optional<HasMetadata> hasMetadata = findResource(applicationResources, ResourceKind.DEPLOYMENT);
+
+        assertThat(hasMetadata)
+                .isPresent()
+                .get(InstanceOfAssertFactories.type(Deployment.class))
+                .satisfies(deployment -> {
+                    final List<LocalObjectReference> imagePullSecrets = deployment.getSpec().getTemplate().getSpec()
+                            .getImagePullSecrets();
+                    assertThat(imagePullSecrets).hasSize(1);
+                    final String imagePullSecret = imagePullSecrets.get(0).getName();
+                    assertThat(imagePullSecret).isEqualTo(DEFAULT_SECRET);
+                });
+    }
+
     private ApplicationResources createApplicationResource(@Nullable final Integer replicas,
-        @Nullable final Integer port,
+        @Nullable final Integer port, @Nullable final String imagePullSecret,
         final Map<String, String> arguments) {
 
         final ApplicationCreationData appCreationData =
             new ApplicationCreationData(NAME, KubernetesTest.DOCKER_REGISTRY, "test",
-                "snapshot", replicas, port, arguments);
+                "snapshot", replicas, port, imagePullSecret, arguments);
 
         return this.loader.forCreation(appCreationData, ResourcePrefix.APPLICATION);
     }

--- a/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
@@ -27,9 +27,16 @@ import com.bakdata.quick.manager.k8s.KubernetesResources;
 import com.bakdata.quick.manager.k8s.KubernetesTest;
 import com.bakdata.quick.manager.k8s.resource.QuickResources.ResourcePrefix;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
+import io.fabric8.kubernetes.api.model.Container;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +99,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
                     });
 
                 final PodSpec podSpec = deploymentSpec.getTemplate().getSpec();
-                assertThat(podSpec.getImagePullSecrets()).isNull();
+                assertThat(podSpec.getImagePullSecrets()).isNullOrEmpty();
                 assertThat(podSpec.getContainers())
                     .isNotNull()
                     .hasSize(1)

--- a/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
@@ -92,7 +92,7 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
                     });
 
                 final PodSpec podSpec = deploymentSpec.getTemplate().getSpec();
-                assertThat(podSpec.getImagePullSecrets()).isEqualTo(null);
+                assertThat(podSpec.getImagePullSecrets()).isNull();
                 assertThat(podSpec.getContainers())
                     .isNotNull()
                     .hasSize(1)

--- a/openapi/spec/schemas.yaml
+++ b/openapi/spec/schemas.yaml
@@ -130,6 +130,8 @@ components:
         port:
           type: integer
           format: int32
+        imagePullSecret:
+          type: string
         arguments:
           type: object
           properties:


### PR DESCRIPTION
This pull request resolves #18.

Assumptions:
1. A user provides only a single secret,
2. We don't make any secret or secret-name validity check, i.e. when a user inputs an empty key name or two secret (comma separated), then the app deployment simply fails.
