### PR TITLE
Fix sonar lint issues

### DIFF
--- a/build-logic/convention/src/main/kotlin/buildlogic/convention/QuickCodeQualityPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/buildlogic/convention/QuickCodeQualityPlugin.kt
@@ -34,6 +34,7 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
+import java.util.*
 
 class QuickCodeQualityPlugin : Plugin<Project> {
     companion object {
@@ -72,7 +73,7 @@ class QuickCodeQualityPlugin : Plugin<Project> {
 
                 // nullaway only for non-tests
                 val nullAwaySeverity =
-                    if (name.toLowerCase().contains("test")) CheckSeverity.OFF else CheckSeverity.ERROR
+                        if (name.toLowerCase(Locale.ROOT).contains("test")) CheckSeverity.OFF else CheckSeverity.ERROR
                 check("NullAway", nullAwaySeverity)
                 option("NullAway:AnnotatedPackages", "com.bakdata.quick")
             }

--- a/build-logic/convention/src/main/kotlin/buildlogic/convention/QuickCodeQualityPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/buildlogic/convention/QuickCodeQualityPlugin.kt
@@ -34,7 +34,6 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
-import java.util.*
 
 class QuickCodeQualityPlugin : Plugin<Project> {
     companion object {
@@ -73,7 +72,7 @@ class QuickCodeQualityPlugin : Plugin<Project> {
 
                 // nullaway only for non-tests
                 val nullAwaySeverity =
-                        if (name.toLowerCase(Locale.ROOT).contains("test")) CheckSeverity.OFF else CheckSeverity.ERROR
+                        if (name.toLowerCase().contains("test")) CheckSeverity.OFF else CheckSeverity.ERROR
                 check("NullAway", nullAwaySeverity)
                 option("NullAway:AnnotatedPackages", "com.bakdata.quick")
             }

--- a/common/src/main/java/com/bakdata/quick/common/api/client/HttpClient.java
+++ b/common/src/main/java/com/bakdata/quick/common/api/client/HttpClient.java
@@ -32,7 +32,7 @@ import okhttp3.Request;
 public class HttpClient {
     public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private final ObjectMapper objectMapper;
-    private final OkHttpClient httpClient;
+    private final OkHttpClient delegate;
 
     /**
      * Default constructor.
@@ -42,16 +42,16 @@ public class HttpClient {
      */
     public HttpClient(final ObjectMapper objectMapper, final OkHttpClient httpClient) {
         this.objectMapper = objectMapper;
-        this.httpClient = httpClient;
+        this.delegate = httpClient;
     }
 
     public HttpClient() {
         this.objectMapper = new ObjectMapper();
-        this.httpClient = new OkHttpClient();
+        this.delegate = new OkHttpClient();
     }
 
     public Call newCall(final Request request) {
-        return this.httpClient.newCall(request);
+        return this.delegate.newCall(request);
     }
 
     public TypeFactory typeFactory() {
@@ -63,7 +63,7 @@ public class HttpClient {
     }
 
     public OkHttpClient okHttpClient() {
-        return this.httpClient;
+        return this.delegate;
     }
 
     /**

--- a/common/src/main/java/com/bakdata/quick/common/api/model/TopicData.java
+++ b/common/src/main/java/com/bakdata/quick/common/api/model/TopicData.java
@@ -16,8 +16,6 @@
 
 package com.bakdata.quick.common.api.model;
 
-import com.bakdata.quick.common.type.QuickTopicData;
-import com.bakdata.quick.common.type.QuickTopicData.QuickData;
 import com.bakdata.quick.common.type.QuickTopicType;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.Value;

--- a/common/src/main/java/com/bakdata/quick/common/config/AvroConfig.java
+++ b/common/src/main/java/com/bakdata/quick/common/config/AvroConfig.java
@@ -38,7 +38,7 @@ import lombok.Getter;
 @Getter
 public class AvroConfig {
     static final String PREFIX = SchemaConfig.PREFIX + ".avro";
-    private static final Pattern NAMESPACE_PATTERN = Pattern.compile("^[A-z_](\\.?\\w)*$");
+    private static final Pattern NAMESPACE_PATTERN = Pattern.compile("^[A-Za-z_]\\w+(\\.[A-Za-z_]\\w+)*+$");
 
     private final String namespace;
 

--- a/common/src/main/java/com/bakdata/quick/common/exception/schema/SchemaNotFoundException.java
+++ b/common/src/main/java/com/bakdata/quick/common/exception/schema/SchemaNotFoundException.java
@@ -16,12 +16,13 @@
 
 package com.bakdata.quick.common.exception.schema;
 
+import com.bakdata.quick.common.exception.QuickException;
 import io.micronaut.http.HttpStatus;
 
 /**
  * Exception when subject doesn't exist.
  */
-public class SchemaNotFoundException extends SchemaException {
+public class SchemaNotFoundException extends QuickException {
     private static final String MESSAGE = "Subject \"%s\" not found in schema registry";
 
     public SchemaNotFoundException(final String subject) {

--- a/common/src/main/java/com/bakdata/quick/common/graphql/GraphQLUtils.java
+++ b/common/src/main/java/com/bakdata/quick/common/graphql/GraphQLUtils.java
@@ -95,9 +95,13 @@ public final class GraphQLUtils {
 
         final Map<String, Integer> objectFiledCount = new HashMap<>();
         final List<String> skippableTypes = new ArrayList<>();
-        for (final Entry<String, TypeDefinition> next : registry.types().entrySet()) {
+
+        // graphql-java returns a raw type of TypeDefintion
+        @SuppressWarnings("unchecked") final Map<String, TypeDefinition<?>> types =
+            (Map<String, TypeDefinition<?>>) (Map<String, ?>) registry.types();
+        for (final Entry<String, ? extends TypeDefinition<?>> next : types.entrySet()) {
             final String typeName = next.getKey();
-            final TypeDefinition typeDefinition = next.getValue();
+            final TypeDefinition<?> typeDefinition = next.getValue();
             if (typeName.equals(QUERY_TYPE) || skippableTypes.contains(typeName)) {
                 // we can skip the query type and type we've already seen
                 continue;
@@ -108,8 +112,8 @@ public final class GraphQLUtils {
                 final int objectTypesAsFieldsCount = (int) fieldDefinitions.stream()
                     .map(FieldDefinition::getType)
                     .map(GraphQLUtils::getNameOfType)
-                    .filter(name -> registry.types().containsKey(name))
-                    .peek(skippableTypes::add) // seen as field => can not be root object
+                    .filter(types::containsKey)
+                    .map(skippableTypes::add) // seen as field => can not be root object
                     .count();
                 objectFiledCount.put(typeName, objectTypesAsFieldsCount);
             } else {

--- a/common/src/main/java/com/bakdata/quick/common/resolver/GenericAvroResolver.java
+++ b/common/src/main/java/com/bakdata/quick/common/resolver/GenericAvroResolver.java
@@ -16,7 +16,6 @@
 
 package com.bakdata.quick.common.resolver;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import org.apache.avro.Schema;

--- a/common/src/main/java/com/bakdata/quick/common/schema/SchemaFetcher.java
+++ b/common/src/main/java/com/bakdata/quick/common/schema/SchemaFetcher.java
@@ -18,7 +18,6 @@ package com.bakdata.quick.common.schema;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.reactivex.Single;
-import org.apache.avro.Schema;
 
 /**
  * Client for interacting with the Avro Schema Registry.

--- a/common/src/main/java/com/bakdata/quick/common/util/CliArgHandler.java
+++ b/common/src/main/java/com/bakdata/quick/common/util/CliArgHandler.java
@@ -62,8 +62,8 @@ public final class CliArgHandler {
      */
     public static List<String> convertArgs(final Map<String, String> args, final KafkaConfig kafkaConfig) {
         final List<String> listArgs = new ArrayList<>();
-        listArgs.add(String.format("%s=%s", "--brokers", kafkaConfig.getBootstrapServer()));
-        listArgs.add(String.format("%s=%s", "--schema-registry-url", kafkaConfig.getSchemaRegistryUrl()));
+        listArgs.add(formatCliArgument("--brokers", kafkaConfig.getBootstrapServer()));
+        listArgs.add(formatCliArgument("--schema-registry-url", kafkaConfig.getSchemaRegistryUrl()));
         args.entrySet().stream().map(CliArgHandler::toCliParameter).forEach(listArgs::add);
         return listArgs;
     }
@@ -73,6 +73,10 @@ public final class CliArgHandler {
         if (!key.startsWith("--")) {
             key = "--" + key;
         }
-        return String.format("%s=%s", key, argument.getValue());
+        return formatCliArgument(key, argument.getValue());
+    }
+
+    private static String formatCliArgument(final String key, final String value) {
+        return String.format("%s=%s", key, value);
     }
 }

--- a/common/src/test/java/com/bakdata/quick/common/config/KafkaConfigTest.java
+++ b/common/src/test/java/com/bakdata/quick/common/config/KafkaConfigTest.java
@@ -66,6 +66,6 @@ class KafkaConfigTest {
 
         assertThat(config.getBootstrapServer()).isEqualTo("localhost:9092");
         assertThat(config.getSchemaRegistryUrl()).isEqualTo("https://localhost:8081");
-        assertThat(config.getApplicationId()).isEqualTo(Optional.empty());
+        assertThat(config.getApplicationId()).isNotPresent();
     }
 }

--- a/common/src/test/java/com/bakdata/quick/common/config/SchemaConfigTest.java
+++ b/common/src/test/java/com/bakdata/quick/common/config/SchemaConfigTest.java
@@ -22,26 +22,15 @@ import com.bakdata.quick.common.ConfigUtils;
 import com.bakdata.quick.common.schema.SchemaFormat;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class SchemaConfigTest {
 
-    @Test
-    void shouldCreateConfigWithProtobuf() {
-        final Map<String, Object> properties = Map.of("quick.schema.format", "protobuf");
-        final SchemaConfig schemaConfig = ConfigUtils.createWithProperties(properties, SchemaConfig.class);
-        assertThat(schemaConfig.getFormat()).isEqualTo(SchemaFormat.PROTOBUF);
-    }
-
-    @Test
-    void shouldReadFormatCaseInsensitive() {
-        final Map<String, Object> properties = Map.of("quick.schema.format", "Protobuf");
-        final SchemaConfig schemaConfig = ConfigUtils.createWithProperties(properties, SchemaConfig.class);
-        assertThat(schemaConfig.getFormat()).isEqualTo(SchemaFormat.PROTOBUF);
-    }
-
-    @Test
-    void shouldCreateConfigFromCaps() {
-        final Map<String, Object> properties = Map.of("quick.schema.format", "PROTOBUF");
+    @ParameterizedTest
+    @CsvSource({"protobuf", "Protobuf", "PROTOBUF"})
+    void shouldCreateConfigWithProtobuf(final String protobufConfig) {
+        final Map<String, Object> properties = Map.of("quick.schema.format", protobufConfig);
         final SchemaConfig schemaConfig = ConfigUtils.createWithProperties(properties, SchemaConfig.class);
         assertThat(schemaConfig.getFormat()).isEqualTo(SchemaFormat.PROTOBUF);
     }

--- a/common/src/testFixtures/java/com/bakdata/quick/common/TestEnvironmentPropertySource.java
+++ b/common/src/testFixtures/java/com/bakdata/quick/common/TestEnvironmentPropertySource.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class TestEnvironmentPropertySource extends MapPropertySource {
     public static final String NAME = "test";
 
-    public TestEnvironmentPropertySource(final Map map) {
+    public TestEnvironmentPropertySource(final Map<?, ?> map) {
         super(NAME, map);
     }
 

--- a/common/src/testFixtures/java/com/bakdata/quick/common/TestTypeUtils.java
+++ b/common/src/testFixtures/java/com/bakdata/quick/common/TestTypeUtils.java
@@ -23,7 +23,6 @@ import com.bakdata.quick.common.resolver.LongResolver;
 import com.bakdata.quick.common.resolver.StringResolver;
 import com.bakdata.quick.common.type.QuickTopicData.QuickData;
 import com.bakdata.quick.common.type.QuickTopicType;
-import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;

--- a/gateway/src/main/java/com/bakdata/quick/gateway/GatewayInitializer.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/GatewayInitializer.java
@@ -19,6 +19,7 @@ package com.bakdata.quick.gateway;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.event.StartupEvent;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.inject.Inject;
@@ -59,7 +60,7 @@ public class GatewayInitializer implements ApplicationEventListener<StartupEvent
             }
         } catch (final IOException e) {
             // something went seriously wrong, shut down
-            throw new RuntimeException("Something went wrong while reading the schema", e);
+            throw new UncheckedIOException("Something went wrong while reading the schema", e);
         }
     }
 }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/QuickGraphQLContext.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/QuickGraphQLContext.java
@@ -70,8 +70,7 @@ public class QuickGraphQLContext {
      * Creates a new GraphQLSchema from a schema string and updates it.
      */
     public void updateFromSchemaString(final String schemaString) {
-        final GraphQLSchema graphQLSchema = this.schemaGenerator.create(schemaString);
-        this.update(graphQLSchema);
+        this.update(this.schemaGenerator.create(schemaString));
     }
 
     public GraphQL getGraphQL() {

--- a/gateway/src/main/java/com/bakdata/quick/gateway/directives/QuickDirectiveWiring.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/directives/QuickDirectiveWiring.java
@@ -32,7 +32,7 @@ public interface QuickDirectiveWiring extends SchemaDirectiveWiring {
      * Returns name of the directive.
      *
      * <p>
-     * Example: @deprecated(reason: "something") --> Name in this case would be 'deprecated'
+     * Example: {@code @skip(if: Boolean!)} --> Name in this case would be 'skip'
      */
     String getName();
 }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/directives/rest/RestDirective.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/directives/rest/RestDirective.java
@@ -33,10 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import lombok.Getter;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.ListTopicsOptions;
 
 /**
  * Custom GraphQL directive for allowing integration of arbitrary REST services.

--- a/gateway/src/main/java/com/bakdata/quick/gateway/directives/rest/RestDirectiveWiring.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/directives/rest/RestDirectiveWiring.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Singleton;

--- a/gateway/src/main/java/com/bakdata/quick/gateway/directives/topic/TopicDirectiveWiring.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/directives/topic/TopicDirectiveWiring.java
@@ -24,7 +24,6 @@ import com.bakdata.quick.gateway.fetcher.FetcherFactory;
 import graphql.language.DirectiveDefinition;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.idl.SchemaDirectiveWiringEnvironment;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**

--- a/gateway/src/main/java/com/bakdata/quick/gateway/directives/topic/rule/validation/ValidationRules.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/directives/topic/rule/validation/ValidationRules.java
@@ -26,10 +26,10 @@ import java.util.Optional;
  * Validates that a {@link com.bakdata.quick.gateway.directives.topic.TopicDirective} is used correctly.
  */
 public class ValidationRules implements TopicDirectiveRules {
-    private static final List<ValidationRule> validationRules;
+    private static final List<ValidationRule> VALIDATION_RULES;
 
     static {
-        validationRules = List.of(
+        VALIDATION_RULES = List.of(
                 new SubscriptionList(),
                 new ExclusiveArguments(),
                 new KeyInformation(),
@@ -39,7 +39,7 @@ public class ValidationRules implements TopicDirectiveRules {
 
     @Override
     public void apply(final TopicDirectiveContext context) {
-        final Optional<String> error = validationRules.stream()
+        final Optional<String> error = VALIDATION_RULES.stream()
             .map(rule -> rule.validate(context))
             .filter(Optional::isPresent)
             .map(Optional::get)

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/ClientSupplier.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/ClientSupplier.java
@@ -14,20 +14,11 @@
  *    limitations under the License.
  */
 
-package com.bakdata.quick.common.exception.schema;
-
-import com.bakdata.quick.common.exception.QuickException;
-import edu.umd.cs.findbugs.annotations.Nullable;
+package com.bakdata.quick.gateway.fetcher;
 
 /**
- * Exceptions that are thrown when working with schemas.
+ * Supplier for creating a new data fetcher client for a topic.
  */
-public abstract class SchemaException extends QuickException {
-    protected SchemaException(@Nullable final String message) {
-        super(message);
-    }
-
-    public SchemaException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
+public interface ClientSupplier {
+    <T> DataFetcherClient<T> createClient(final String topic);
 }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/DefaultClientSupplier.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/DefaultClientSupplier.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2022 bakdata GmbH
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.bakdata.quick.gateway.fetcher;
+
+import com.bakdata.quick.common.api.client.HttpClient;
+import com.bakdata.quick.common.config.MirrorConfig;
+import com.bakdata.quick.common.exception.NotFoundException;
+import com.bakdata.quick.common.resolver.TypeResolver;
+import com.bakdata.quick.common.type.QuickTopicData;
+import com.bakdata.quick.common.type.TopicTypeService;
+import com.bakdata.quick.common.util.Lazy;
+import io.reactivex.Single;
+
+final class DefaultClientSupplier implements ClientSupplier {
+    private final HttpClient client;
+    private final TopicTypeService topicTypeService;
+    private final MirrorConfig mirrorConfig;
+
+    DefaultClientSupplier(final HttpClient client, final TopicTypeService topicRegistryClient,
+                          final MirrorConfig mirrorConfig) {
+        this.client = client;
+        this.topicTypeService = topicRegistryClient;
+        this.mirrorConfig = mirrorConfig;
+    }
+
+    @Override
+    public <T> DataFetcherClient<T> createClient(final String topic) {
+        return this.doCreateClient(topic);
+    }
+
+    private <T> DataFetcherClient<T> doCreateClient(final String topic) {
+        final Lazy<TypeResolver<T>> quickTopicTypeLazy = new Lazy<>(() -> this.getQuickTopicTypeLazy(topic));
+        return new MirrorDataFetcherClient<>(
+            topic,
+            this.client,
+            this.mirrorConfig,
+            quickTopicTypeLazy
+        );
+    }
+
+    private <T> TypeResolver<T> getQuickTopicTypeLazy(final String topic) {
+        final Single<QuickTopicData<Object, T>> data = this.topicTypeService.getTopicData(topic);
+        final QuickTopicData<?, T> topicData = data.blockingGet();
+        if (topicData == null) {
+            throw new NotFoundException("Could not find topic " + topic);
+        }
+        return topicData.getValueData().getResolver();
+    }
+}

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/DeferFetcher.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/DeferFetcher.java
@@ -19,7 +19,6 @@ package com.bakdata.quick.gateway.fetcher;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -71,7 +70,7 @@ public class DeferFetcher implements DataFetcher<DataFetcherResult<Object>> {
         if (environment.containsArgument(argument)) {
             return Optional.ofNullable(environment.getArguments().get(argument));
 
-        } else if (environment.getLocalContext() != null && environment.getLocalContext() instanceof Map) {
+        } else if (environment.getLocalContext() instanceof Map) {
             final Map<String, Object> localContext = environment.getLocalContext();
             return Optional.ofNullable(localContext.get(argument));
         }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/FetcherFactory.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/FetcherFactory.java
@@ -19,8 +19,6 @@ package com.bakdata.quick.gateway.fetcher;
 import com.bakdata.quick.common.api.client.HttpClient;
 import com.bakdata.quick.common.config.KafkaConfig;
 import com.bakdata.quick.common.config.MirrorConfig;
-import com.bakdata.quick.common.exception.NotFoundException;
-import com.bakdata.quick.common.resolver.TypeResolver;
 import com.bakdata.quick.common.type.QuickTopicData;
 import com.bakdata.quick.common.type.TopicTypeService;
 import com.bakdata.quick.common.util.Lazy;
@@ -31,12 +29,14 @@ import com.bakdata.quick.gateway.ingest.KafkaIngestService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import io.reactivex.Single;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.Publisher;
 
 /**
  * Factory for instantiating the different {@link DataFetcher} used in Quick.
@@ -75,25 +75,27 @@ public class FetcherFactory {
             new DefaultClientSupplier(client, topicTypeService, mirrorConfig), topicTypeService);
     }
 
-    public DataFetcher<?> subscriptionFetcher(final String topic, final String operationName,
-        @Nullable final String argument) {
-        return new SubscriptionFetcher<>(this.kafkaConfig, this.getTopicData(topic), operationName,
-            argument);
+    public <K, V> DataFetcher<Publisher<V>> subscriptionFetcher(final String topic, final String operationName,
+                                                                @Nullable final String argument) {
+        final Lazy<QuickTopicData<K, V>> topicData = this.getTopicData(topic);
+        return new SubscriptionFetcher<>(this.kafkaConfig, topicData, operationName, argument);
     }
 
-    public DataFetcher<?> queryFetcher(final String topic, final String argument, final boolean isNullable) {
-        return new QueryKeyArgumentFetcher<>(argument, this.clientSupplier.createClient(topic), isNullable);
+    public <V> DataFetcher<V> queryFetcher(final String topic, final String argument, final boolean isNullable) {
+        final DataFetcherClient<V> client = this.clientSupplier.createClient(topic);
+        return new QueryKeyArgumentFetcher<>(argument, client, isNullable);
     }
 
-    public DataFetcher<?> queryListFetcher(final String topic, final boolean isNullable,
-        final boolean hasNullableElements) {
-        return new QueryListFetcher<>(this.clientSupplier.createClient(topic), isNullable, hasNullableElements);
+    public <V> DataFetcher<List<V>> queryListFetcher(final String topic, final boolean isNullable,
+                                                     final boolean hasNullableElements) {
+        final DataFetcherClient<V> client = this.clientSupplier.createClient(topic);
+        return new QueryListFetcher<>(client, isNullable, hasNullableElements);
     }
 
-    public DataFetcher<?> listArgumentFetcher(final String topic, final String argument, final boolean isNullable,
-        final boolean hasNullableElements) {
-        return new ListArgumentFetcher<>(argument, this.clientSupplier.createClient(topic), isNullable,
-            hasNullableElements);
+    public <V> DataFetcher<List<V>> listArgumentFetcher(final String topic, final String argument,
+                                                        final boolean isNullable, final boolean hasNullableElements) {
+        final DataFetcherClient<V> client = this.clientSupplier.createClient(topic);
+        return new ListArgumentFetcher<>(argument, client, isNullable, hasNullableElements);
     }
 
     /**
@@ -101,36 +103,37 @@ public class FetcherFactory {
      *
      * @see MutationFetcher
      */
-    public DataFetcher<?> mutationFetcher(final String topic, final String keyArgumentName,
-        final String valueArgumentName) {
+    public <K, V> DataFetcher<V> mutationFetcher(final String topic, final String keyArgumentName,
+                                                 final String valueArgumentName) {
+        final Lazy<QuickTopicData<K, V>> data = this.getTopicDataWithTopicTypeService(topic);
         return new MutationFetcher<>(topic,
             keyArgumentName,
             valueArgumentName,
-            this.getTopicDataWithTopicTypeService(topic),
+            data,
             new KafkaIngestService(this.topicTypeService, this.kafkaConfig),
             this.objectMapper
         );
     }
 
-    public DataFetcher<?> listFieldFetcher(final String topic, final String keyFieldName) {
+    public <V> DataFetcher<List<V>> listFieldFetcher(final String topic, final String keyFieldName) {
         return new ListFieldFetcher<>(keyFieldName, this.clientSupplier.createClient(topic));
     }
 
-    public DataFetcher<?> keyFieldFetcher(final String topic, final String keyFieldName) {
+    public DataFetcher<Object> keyFieldFetcher(final String topic, final String keyFieldName) {
         return new KeyFieldFetcher<>(this.objectMapper, keyFieldName, this.clientSupplier.createClient(topic));
     }
 
-    public SubscriptionProvider<?, ?> subscriptionProvider(final String topic, final String operationName,
-        @Nullable final String argument) {
+    public <K, V> SubscriptionProvider<K, V> subscriptionProvider(final String topic, final String operationName,
+                                                                  @Nullable final String argument) {
         return new KafkaSubscriptionProvider<>(this.kafkaConfig, this.getTopicData(topic), operationName,
             argument);
     }
 
-    public DataFetcherClient<?> dataFetcherClient(final String topic) {
+    public <V> DataFetcherClient<V> dataFetcherClient(final String topic) {
         return this.clientSupplier.createClient(topic);
     }
 
-    public DataFetcher<?> deferFetcher() {
+    public DataFetcher<DataFetcherResult<Object>> deferFetcher() {
         return new DeferFetcher();
     }
 
@@ -149,50 +152,4 @@ public class FetcherFactory {
         });
     }
 
-
-    /**
-     * Supplier for creating a new data fetcher client for a topic.
-     */
-    public interface ClientSupplier {
-        DataFetcherClient<?> createClient(final String topic);
-    }
-
-    static final class DefaultClientSupplier implements ClientSupplier {
-        private final HttpClient client;
-        private final TopicTypeService topicTypeService;
-        private final MirrorConfig mirrorConfig;
-
-        private DefaultClientSupplier(final HttpClient client, final TopicTypeService topicRegistryClient,
-                                      final MirrorConfig mirrorConfig) {
-            this.client = client;
-            this.topicTypeService = topicRegistryClient;
-            this.mirrorConfig = mirrorConfig;
-        }
-
-        @Override
-        public DataFetcherClient<?> createClient(final String topic) {
-            return this.doCreateClient(topic);
-        }
-
-        private  <T> DataFetcherClient<T> doCreateClient(final String topic) {
-            final Lazy<TypeResolver<T>> quickTopicTypeLazy = this.getQuickTopicTypeLazy(topic);
-            return new MirrorDataFetcherClient<>(
-                topic,
-                this.client,
-                this.mirrorConfig,
-                quickTopicTypeLazy
-            );
-        }
-
-        private <T> Lazy<TypeResolver<T>> getQuickTopicTypeLazy(final String topic) {
-            return new Lazy<>(() -> {
-                final Single<QuickTopicData<Object, T>> data = this.topicTypeService.getTopicData(topic);
-                final QuickTopicData<?, T> topicData = data.blockingGet();
-                if (topicData == null) {
-                    throw new NotFoundException("Could not find topic " + topic);
-                }
-                return topicData.getValueData().getResolver();
-            });
-        }
-    }
 }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/KeyFieldFetcher.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/KeyFieldFetcher.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
@@ -114,23 +115,23 @@ public class KeyFieldFetcher<T> implements DataFetcher<Object> {
                 return Stream.of(this.valueAsString(node));
             }
         } catch (final JsonProcessingException e) {
-            throw new RuntimeException("Could not process json: " + parentJson, e);
+            throw new UncheckedIOException("Could not process json: " + parentJson, e);
         }
     }
 
     private String extractJson(final DataFetchingEnvironment environment) {
         // this is only needed for subscriptions because we use the data directly.
         if (environment.getSource() instanceof GenericRecord) {
-            final GenericRecord record = environment.getSource();
+            final GenericRecord genericRecord = environment.getSource();
             // TODO this is pretty expensive for a frequent operation. Thus, we should operate on the record directly.
-            return new String(this.converter.convertToJson(record), StandardCharsets.UTF_8);
+            return new String(this.converter.convertToJson(genericRecord), StandardCharsets.UTF_8);
         }
 
         final Map<String, Object> value = environment.getSource();
         try {
             return this.objectMapper.writeValueAsString(value);
         } catch (final JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -139,7 +140,7 @@ public class KeyFieldFetcher<T> implements DataFetcher<Object> {
             // strings are written as "value". therefore we strip the ".
             return this.objectMapper.writeValueAsString(node).replace("\"", "");
         } catch (final JsonProcessingException e) {
-            throw new RuntimeException("Could not process json: " + node, e);
+            throw new UncheckedIOException("Could not process json: " + node, e);
         }
     }
 }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/ListFieldFetcher.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/ListFieldFetcher.java
@@ -55,8 +55,8 @@ public class ListFieldFetcher<T, V> implements DataFetcher<List<V>> {
         // in case of a subscription, we get a generic record directly from the Kafka Consumer
         final List<T> keys;
         if (environment.getSource() instanceof GenericRecord) {
-            final GenericRecord record = environment.getSource();
-            keys = (List<T>) record.get(this.idFieldName);
+            final GenericRecord genericRecord = environment.getSource();
+            keys = (List<T>) genericRecord.get(this.idFieldName);
         } else {
             // otherwise, it's a from a request to a mirror and therefore json, i.e. a map
             final Map<String, Object> source = environment.getSource();

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/MutationFetcher.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/MutationFetcher.java
@@ -22,6 +22,7 @@ import com.bakdata.quick.common.util.Lazy;
 import com.bakdata.quick.gateway.ingest.KafkaIngestService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import graphql.GraphQLException;
 import graphql.GraphqlErrorException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -99,7 +100,7 @@ public class MutationFetcher<K, V> implements DataFetcher<V> {
         final Throwable throwable = this.kafkaIngestService.sendData(this.topic, List.of(keyValuePair)).blockingGet();
 
         if (throwable != null) {
-            throw new RuntimeException(throwable);
+            throw new GraphQLException(throwable);
         }
 
         return resolvedValue;

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/QueryKeyArgumentFetcher.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/QueryKeyArgumentFetcher.java
@@ -47,9 +47,9 @@ public class QueryKeyArgumentFetcher<T> implements DataFetcher<T> {
     @Override
     @Nullable
     public T get(final DataFetchingEnvironment environment) {
-        final Object argument = DeferFetcher.getArgument(this.argument, environment)
+        final Object argumentValue = DeferFetcher.getArgument(this.argument, environment)
             .orElseThrow(() -> new RuntimeException("Could not find argument " + this.argument));
-        final T value = this.dataFetcherClient.fetchResult(argument.toString());
+        final T value = this.dataFetcherClient.fetchResult(argumentValue.toString());
         if (value == null && !this.isNullable) {
             throw new NonNullableFieldWasNullException(environment.getExecutionStepInfo(),
                 environment.getExecutionStepInfo().getPath());

--- a/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/subscription/KafkaSubscriptionProvider.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/fetcher/subscription/KafkaSubscriptionProvider.java
@@ -125,7 +125,7 @@ public class KafkaSubscriptionProvider<K, V> implements SubscriptionProvider<K, 
             final Object requestedKeyValue = Optional.ofNullable(environment.getArgument(this.key))
                 .orElseThrow(() -> new IllegalArgumentException("Could not get argument"));
 
-            recordFlux = recordFlux.filter(record -> record.key().equals(requestedKeyValue));
+            recordFlux = recordFlux.filter(consumerRecord -> consumerRecord.key().equals(requestedKeyValue));
         }
         // Do NOT cache the results of the publisher
         // this may lead to sending elements downstream multiple times if a subscriber renews the subscription

--- a/gateway/src/main/java/com/bakdata/quick/gateway/subscriptions/GraphQLWsOperations.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/subscriptions/GraphQLWsOperations.java
@@ -92,7 +92,7 @@ class GraphQLWsOperations {
     boolean operationExists(final GraphQLWsRequest request) {
         return Optional.ofNullable(request)
             .map(GraphQLWsRequest::getId)
-            .map(id -> this.activeOperations.containsKey(id))
+            .map(this.activeOperations::containsKey)
             .orElse(false);
     }
 }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/subscriptions/GraphQLWsState.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/subscriptions/GraphQLWsState.java
@@ -98,9 +98,7 @@ class GraphQLWsState {
     void saveOperation(final String operationId, final WebSocketSession session,
         final Function<String, Subscription> starter) {
         Optional.ofNullable(session)
-            .map(session1 -> {
-                return session1.getId();
-            })
+            .map(WebSocketSession::getId)
             .map(this.activeOperations::get)
             .ifPresent(graphQLWsOperations -> graphQLWsOperations.addSubscription(operationId, starter));
     }

--- a/gateway/src/main/java/com/bakdata/quick/gateway/transformer/MultiSubscriptionTransformer.java
+++ b/gateway/src/main/java/com/bakdata/quick/gateway/transformer/MultiSubscriptionTransformer.java
@@ -63,9 +63,9 @@ public class MultiSubscriptionTransformer implements SchemaGeneratorPostProcessi
                 .map(this::buildDataFetcher)
                 .collect(Collectors.toList());
 
-        final GraphQLCodeRegistry codeRegistry = originalSchema.getCodeRegistry().transform(builder -> {
-            fetchers.forEach(spec -> builder.dataFetcher(spec.getCoordinates(), spec.getDataFetcher()));
-        });
+        final GraphQLCodeRegistry codeRegistry = originalSchema.getCodeRegistry().transform(builder ->
+            fetchers.forEach(spec -> builder.dataFetcher(spec.getCoordinates(), spec.getDataFetcher()))
+        );
 
         return originalSchema.transform(builder -> builder.codeRegistry(codeRegistry));
     }

--- a/gateway/src/test/java/com/bakdata/quick/gateway/ControllerReturnSchemaTest.java
+++ b/gateway/src/test/java/com/bakdata/quick/gateway/ControllerReturnSchemaTest.java
@@ -30,6 +30,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -105,8 +106,9 @@ class ControllerReturnSchemaTest {
     @Test
     void shouldThrowErrorIfTypeDoesNotExist() {
         final HttpRequest<?> request = HttpRequest.create(HttpMethod.GET, "/schema/nope");
+        final BlockingHttpClient blockingClient = this.httpClient.toBlocking();
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.httpClient.retrieve(request).blockingFirst())
+            .isThrownBy(() -> blockingClient.retrieve(request))
             .isInstanceOfSatisfying(HttpClientResponseException.class, ex ->
                 assertThat(extractErrorMessage(ex))
                     .isPresent()

--- a/gateway/src/test/java/com/bakdata/quick/gateway/ControllerUpdateSchemaTest.java
+++ b/gateway/src/test/java/com/bakdata/quick/gateway/ControllerUpdateSchemaTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -57,8 +58,9 @@ class ControllerUpdateSchemaTest {
         final HttpRequest<?> httpRequest =
             HttpRequest.create(HttpMethod.POST, "/control/schema");
 
+        final BlockingHttpClient blockingHttpClient = this.httpClient.toBlocking();
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.httpClient.retrieve(httpRequest).blockingFirst())
+            .isThrownBy(() -> blockingHttpClient.retrieve(httpRequest))
             .isInstanceOfSatisfying(HttpClientResponseException.class, ex ->
                 assertThat(extractErrorMessage(ex))
                     .isPresent()
@@ -75,8 +77,9 @@ class ControllerUpdateSchemaTest {
         final HttpRequest<?> httpRequest = HttpRequest.create(HttpMethod.POST, "/control/schema")
             .body(new SchemaData("test"));
 
+        final BlockingHttpClient blockingHttpClient = this.httpClient.toBlocking();
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.httpClient.retrieve(httpRequest).blockingFirst())
+            .isThrownBy(() -> blockingHttpClient.retrieve(httpRequest))
             .isInstanceOfSatisfying(HttpClientResponseException.class,
                 ex -> assertThat(extractErrorMessage(ex))
                     .isPresent()

--- a/gateway/src/test/java/com/bakdata/quick/gateway/GraphQLSchemaGeneratorTest.java
+++ b/gateway/src/test/java/com/bakdata/quick/gateway/GraphQLSchemaGeneratorTest.java
@@ -472,44 +472,49 @@ class GraphQLSchemaGeneratorTest {
     }
 
     @Test
-    void shouldNotConvertIfMissingKeyInfoInQueryType(final TestInfo testInfo) {
+    void shouldNotConvertIfMissingKeyInfoInQueryType(final TestInfo testInfo) throws IOException {
         final Path schemaPath = workingDirectory.resolve(testInfo.getTestMethod().orElseThrow().getName() + ".graphql");
+        String schema = Files.readString(schemaPath);
         assertThatExceptionOfType(QuickDirectiveException.class)
-                .isThrownBy(() -> this.generator.create(Files.readString(schemaPath)))
+                .isThrownBy(() -> this.generator.create(schema))
                 .withMessage("When the return type is not a list for a non-mutation and non-subscription type,"
                         + " key information (keyArgument or keyField) is needed.");
     }
 
     @Test
-    void shouldNotConvertIfMissingKeyInfoInBasicType(final TestInfo testInfo) {
+    void shouldNotConvertIfMissingKeyInfoInBasicType(final TestInfo testInfo) throws IOException {
         final Path schemaPath = workingDirectory.resolve(testInfo.getTestMethod().orElseThrow().getName() + ".graphql");
+        final String schema = Files.readString(schemaPath);
         assertThatExceptionOfType(QuickDirectiveException.class)
-                .isThrownBy(() -> this.generator.create(Files.readString(schemaPath)))
+                .isThrownBy(() -> this.generator.create(schema))
                 .withMessage("When the return type is not a list for a non-mutation and non-subscription type,"
                         + " key information (keyArgument or keyField) is needed.");
     }
 
     @Test
-    void shouldNotConvertIfMutationDoesNotHaveTwoArgs(final TestInfo testInfo) {
+    void shouldNotConvertIfMutationDoesNotHaveTwoArgs(final TestInfo testInfo) throws IOException {
         final Path schemaPath = workingDirectory.resolve(testInfo.getTestMethod().orElseThrow().getName() + ".graphql");
+        final String schema = Files.readString(schemaPath);
         assertThatExceptionOfType(QuickDirectiveException.class)
-                .isThrownBy(() -> this.generator.create(Files.readString(schemaPath)))
+                .isThrownBy(() -> this.generator.create(schema))
                 .withMessage("Mutation requires two input arguments");
     }
 
     @Test
-    void shouldNotConvertIfKeyArgAndInputNameDifferentInQueryType(final TestInfo testInfo) {
+    void shouldNotConvertIfKeyArgAndInputNameDifferentInQueryType(final TestInfo testInfo) throws IOException {
         final Path schemaPath = workingDirectory.resolve(testInfo.getTestMethod().orElseThrow().getName() + ".graphql");
+        final String schema = Files.readString(schemaPath);
         assertThatExceptionOfType(QuickDirectiveException.class)
-                .isThrownBy(() -> this.generator.create(Files.readString(schemaPath)))
+                .isThrownBy(() -> this.generator.create(schema))
                 .withMessage("Key argument has to be identical to the input name.");
     }
 
     @Test
-    void shouldNotConvertIfKeyArgAndInputNameDifferentInNonQueryType(final TestInfo testInfo) {
+    void shouldNotConvertIfKeyArgAndInputNameDifferentInNonQueryType(final TestInfo testInfo) throws IOException {
         final Path schemaPath = workingDirectory.resolve(testInfo.getTestMethod().orElseThrow().getName() + ".graphql");
+        final String schema = Files.readString(schemaPath);
         assertThatExceptionOfType(QuickDirectiveException.class)
-                .isThrownBy(() -> this.generator.create(Files.readString(schemaPath)))
+                .isThrownBy(() -> this.generator.create(schema))
                 .withMessage("Key argument has to be identical to the input name.");
     }
 

--- a/gateway/src/test/java/com/bakdata/quick/gateway/GraphQLSecurityTest.java
+++ b/gateway/src/test/java/com/bakdata/quick/gateway/GraphQLSecurityTest.java
@@ -33,6 +33,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -72,8 +73,9 @@ class GraphQLSecurityTest {
             .header("X-API-Key", "no")
             .body("{test(id: 123)}");
 
+        final BlockingHttpClient httpClient = this.client.toBlocking();
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.client.toBlocking().exchange(request))
+            .isThrownBy(() -> httpClient.exchange(request))
             .withMessage("Unauthorized");
     }
 

--- a/gateway/src/test/java/com/bakdata/quick/gateway/GraphQLTestUtil.java
+++ b/gateway/src/test/java/com/bakdata/quick/gateway/GraphQLTestUtil.java
@@ -19,7 +19,7 @@ package com.bakdata.quick.gateway;
 import static org.mockito.Mockito.mock;
 
 import com.bakdata.quick.gateway.fetcher.DataFetcherClient;
-import com.bakdata.quick.gateway.fetcher.FetcherFactory.ClientSupplier;
+import com.bakdata.quick.gateway.fetcher.ClientSupplier;
 import graphql.schema.DataFetcher;
 import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLFieldDefinition;

--- a/ingest/src/main/java/com/bakdata/quick/ingest/service/IngestFilter.java
+++ b/ingest/src/main/java/com/bakdata/quick/ingest/service/IngestFilter.java
@@ -78,14 +78,14 @@ public class IngestFilter {
 
     private <K, V> Single<IngestLists<K, V>> getExistingKeys(final QuickTopicData<K, V> topicData,
         final List<KeyValuePair<K, V>> pairs) {
-        final MirrorClient<K, V> client =
+        final MirrorClient<K, V> mirrorClient =
             new DefaultMirrorClient<>(topicData.getName(), this.client, this.mirrorConfig,
                 topicData.getValueData().getResolver());
 
         return Flowable.fromIterable(pairs)
             .map(pair -> {
                     // add info whether the key already exists
-                    final boolean keyExists = client.exists(pair.getKey());
+                    final boolean keyExists = mirrorClient.exists(pair.getKey());
                     return IngestPair.from(pair, keyExists);
                 }
             )

--- a/ingest/src/test/java/com/bakdata/quick/ingest/controller/IngestControllerTest.java
+++ b/ingest/src/test/java/com/bakdata/quick/ingest/controller/IngestControllerTest.java
@@ -52,6 +52,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -261,9 +262,10 @@ class IngestControllerTest {
         final String expectedErrorMessage =
             String.format("Could not find 'key' or 'value' fields in: %s", jsonWithNoKeyValueField);
 
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final HttpRequest<?> request = creatIngestRequest(jsonWithNoKeyValueField);
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(
-                () -> this.client.retrieve(creatIngestRequest(jsonWithNoKeyValueField)).blockingFirst())
+            .isThrownBy(() -> httpClient.retrieve(request))
             .isInstanceOfSatisfying(HttpClientResponseException.class,
                 ex -> assertThat(this.extractErrorMessage(ex))
                     .isPresent()
@@ -283,8 +285,10 @@ class IngestControllerTest {
         final String expectedErrorMessage =
             "Data does not conform to schema: Field fieldId type:LONG pos:0 not set and has no default value";
 
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final HttpRequest<?> request = creatIngestRequest(invalidJsonRecord);
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.client.retrieve(creatIngestRequest(invalidJsonRecord)).blockingFirst())
+            .isThrownBy(() -> httpClient.retrieve(request))
             .isInstanceOfSatisfying(HttpClientResponseException.class,
                 ex -> assertThat(this.extractErrorMessage(ex))
                     .isPresent()
@@ -309,8 +313,10 @@ class IngestControllerTest {
         final String expectedErrorMessage =
             String.format("Data must be of type %s. Got:", type.toString().toLowerCase());
 
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final HttpRequest<?> request = creatIngestRequest(pair);
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.client.retrieve(creatIngestRequest(pair)).blockingFirst())
+            .isThrownBy(() -> httpClient.retrieve(request))
             .isInstanceOfSatisfying(HttpClientResponseException.class,
                 ex -> assertThat(this.extractErrorMessage(ex))
                     .isPresent()
@@ -323,8 +329,10 @@ class IngestControllerTest {
 
     @Test
     void testMethodNotAllowed() {
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final HttpRequest<?> request = HttpRequest.GET("/topic/");
         assertThatExceptionOfType(HttpClientResponseException.class)
-            .isThrownBy(() -> this.client.toBlocking().exchange(HttpRequest.GET("/topic/")))
+            .isThrownBy(() -> httpClient.retrieve(request))
             .withMessage("Method Not Allowed")
             .satisfies(ex -> assertThat((CharSequence) ex.getStatus()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED));
     }

--- a/manager/src/main/java/com/bakdata/quick/manager/config/DeploymentConfig.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/config/DeploymentConfig.java
@@ -20,7 +20,6 @@ import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import java.util.Optional;
 import lombok.Getter;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Configuration regarding deployments executed by the manager.

--- a/manager/src/main/java/com/bakdata/quick/manager/graphql/GraphQLToProtobufConverter.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/graphql/GraphQLToProtobufConverter.java
@@ -28,12 +28,10 @@ import com.bakdata.quick.common.exception.BadArgumentException;
 import com.bakdata.quick.common.exception.InternalErrorException;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
-import com.google.protobuf.DescriptorProtos.DescriptorProto.Builder;
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
 import com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label;
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -69,7 +67,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
     @Getter
     private final String protobufPackage;
 
-    private static final Map<GraphQLScalarType, Type> SCALAR_MAPPING = scalarTypeMap();
+    private static final Map<GraphQLScalarType, FieldDescriptorProto.Type> SCALAR_MAPPING = scalarTypeMap();
 
     @Inject
     public GraphQLToProtobufConverter(final ProtobufConfig protobufConfig) {
@@ -119,7 +117,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
         final List<GraphQLFieldDefinition> fieldDefinitions,
         final FileDescriptorProto.Builder fileBuilder) {
 
-        final Builder currentMessage = DescriptorProto.newBuilder().setName(messageName);
+        final DescriptorProto.Builder currentMessage = DescriptorProto.newBuilder().setName(messageName);
 
         for (int index = 0; index < fieldDefinitions.size(); index++) {
 
@@ -183,7 +181,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
         final GraphQLObjectType graphQLObjectType) {
         currentMessage.addField(createFieldWithType(graphQLFieldDefinition.getName(),
             fieldNumber,
-            Type.TYPE_MESSAGE,
+            FieldDescriptorProto.Type.TYPE_MESSAGE,
             graphQLObjectType.getName(),
             label));
 
@@ -207,7 +205,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
     private static FieldDescriptorProto createFieldWithType(
         final String fieldName,
         final int fieldNumber,
-        final Type type,
+        final FieldDescriptorProto.Type type,
         final String typeName,
         final Label label) {
 
@@ -221,7 +219,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
     }
 
     /**
-     * Creates a {@link FieldDescriptorProto} object from a scalar GraphQL type.
+     * Creates a {@link FieldDescriptorProto} object from a scalar GraphQL FieldDescriptorProto.Type.
      */
     private static FieldDescriptorProto createFieldDescriptorForScalarType(
         final GraphQLScalarType graphQLScalarType,
@@ -229,7 +227,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
         final int fieldNumber,
         final Label label) {
 
-        final Type protoType = SCALAR_MAPPING.get(graphQLScalarType);
+        final FieldDescriptorProto.Type protoType = SCALAR_MAPPING.get(graphQLScalarType);
         if (protoType == null) {
             final String message =
                 String.format("Scalar %s not supported", GraphQLTypeUtil.simplePrint(graphQLScalarType));
@@ -257,7 +255,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
 
         currentMessage.addField(createFieldWithType(graphQLFieldDefinition.getName(),
             fieldNumber,
-            Type.TYPE_ENUM,
+            FieldDescriptorProto.Type.TYPE_ENUM,
             graphQLEnumType.getName(),
             label));
 
@@ -268,7 +266,7 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
     }
 
     /**
-     * Creates a {@link EnumDescriptorProto} object from a scalar GraphQL type. For example the GraphQL * enum with
+     * Creates a {@link EnumDescriptorProto} object from a scalar GraphQL type. For example the GraphQL enum with
      * these fields:
      * <pre>
      * enum Foo {
@@ -335,16 +333,16 @@ public class GraphQLToProtobufConverter implements GraphQLConverter {
             Label.LABEL_REPEATED);
     }
 
-    private static Map<GraphQLScalarType, Type> scalarTypeMap() {
+    private static Map<GraphQLScalarType, FieldDescriptorProto.Type> scalarTypeMap() {
         return Map.of(
-            Scalars.GraphQLInt, Type.TYPE_INT32,
-            Scalars.GraphQLFloat, Type.TYPE_FLOAT,
-            Scalars.GraphQLString, Type.TYPE_STRING,
-            Scalars.GraphQLBoolean, Type.TYPE_BOOL,
-            Scalars.GraphQLID, Type.TYPE_STRING,
-            Scalars.GraphQLLong, Type.TYPE_INT64,
-            Scalars.GraphQLShort, Type.TYPE_INT32,
-            Scalars.GraphQLChar, Type.TYPE_STRING
+            Scalars.GraphQLInt, FieldDescriptorProto.Type.TYPE_INT32,
+            Scalars.GraphQLFloat, FieldDescriptorProto.Type.TYPE_FLOAT,
+            Scalars.GraphQLString, FieldDescriptorProto.Type.TYPE_STRING,
+            Scalars.GraphQLBoolean, FieldDescriptorProto.Type.TYPE_BOOL,
+            Scalars.GraphQLID, FieldDescriptorProto.Type.TYPE_STRING,
+            Scalars.GraphQLLong, FieldDescriptorProto.Type.TYPE_INT64,
+            Scalars.GraphQLShort, FieldDescriptorProto.Type.TYPE_INT32,
+            Scalars.GraphQLChar, FieldDescriptorProto.Type.TYPE_STRING
         );
     }
 }

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesResources.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/KubernetesResources.java
@@ -18,14 +18,9 @@ package com.bakdata.quick.manager.k8s;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.utils.Serialization;
-import io.micronaut.core.annotation.Nullable;
 import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
 import javax.inject.Singleton;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;

--- a/manager/src/main/java/com/bakdata/quick/manager/k8s/cluster/TopicRegistryInitializer.java
+++ b/manager/src/main/java/com/bakdata/quick/manager/k8s/cluster/TopicRegistryInitializer.java
@@ -24,6 +24,8 @@ import com.bakdata.quick.common.config.KafkaConfig;
 import com.bakdata.quick.common.config.TopicRegistryConfig;
 import com.bakdata.quick.common.exception.InternalErrorException;
 import com.bakdata.quick.manager.mirror.MirrorService;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -95,7 +97,7 @@ public class TopicRegistryInitializer {
         // register the avro schema of the topic data class with the schema registry
         try {
             final String subject = VALUE.asSubject(this.topicRegistryConfig.getTopicName());
-            final Schema topicDataSchema = AvroTopicData.getClassSchema();
+            final ParsedSchema topicDataSchema = new AvroSchema(AvroTopicData.getClassSchema());
             this.schemaRegistryClient.register(subject, topicDataSchema);
         } catch (final IOException | RestClientException exception) {
             if (!registryExists) {

--- a/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/application/resources/ApplicationResourceLoaderTest.java
@@ -27,6 +27,7 @@ import com.bakdata.quick.manager.k8s.KubernetesResources;
 import com.bakdata.quick.manager.k8s.KubernetesTest;
 import com.bakdata.quick.manager.k8s.resource.QuickResources.ResourcePrefix;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvFromSource;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -35,7 +36,6 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import java.util.List;
 import java.util.Map;
@@ -252,9 +252,9 @@ class ApplicationResourceLoaderTest extends KubernetesTest {
         assertThat(hasMetadata)
             .isPresent()
             .get(InstanceOfAssertFactories.type(Deployment.class))
-            .satisfies(
-                deployment -> assertThat(deployment.getMetadata().getAnnotations().get("d9p.io/has-service")).isEqualTo(
-                    "true"));
+            .satisfies(deployment ->
+                assertThat(deployment.getMetadata().getAnnotations()).containsEntry("d9p.io/has-service", "true")
+            );
     }
 
     @Test

--- a/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/gateway/KubernetesGatewayServiceTest.java
@@ -78,7 +78,7 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
         final List<GatewayDescription> gatewayDescriptionList =
             this.gatewayService.getGatewayList().blockingGet();
 
-        assertThat(gatewayDescriptionList.size()).isEqualTo(2);
+        assertThat(gatewayDescriptionList).hasSize(2);
         assertThat(gatewayDescriptionList)
             .extracting(GatewayDescription::getName)
             .containsExactlyInAnyOrder(GATEWAY_NAME, GATEWAY_NAME + "-2");
@@ -235,7 +235,7 @@ class KubernetesGatewayServiceTest extends KubernetesTest {
             .first()
             .satisfies(configMap -> assertThat(configMap.getMetadata().getName())
                 .isEqualTo(DEPLOYMENT_NAME + "-config"))
-            .satisfies(configMap -> assertThat(configMap.getData().get("schema.graphql")).isEqualTo(graphQLSchema));
+            .satisfies(configMap -> assertThat(configMap.getData()).containsEntry("schema.graphql", graphQLSchema));
     }
 
     @Test

--- a/manager/src/test/java/com/bakdata/quick/manager/graphql/GraphQLToAvroConverterTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/graphql/GraphQLToAvroConverterTest.java
@@ -61,7 +61,7 @@ class GraphQLToAvroConverterTest {
             .satisfies(enumType -> assertThat(enumType.getName()).isEqualTo("Status"))
             .extracting(Schema::getEnumSymbols)
             .satisfies(symbols -> {
-                assertThat(symbols.size()).isEqualTo(2);
+                assertThat(symbols).hasSize(2);
                 assertThat(symbols).containsExactly("SOLD", "AVAILABLE");
             });
     }

--- a/manager/src/test/java/com/bakdata/quick/manager/graphql/GraphQLToProtobufConverterTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/graphql/GraphQLToProtobufConverterTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-public class GraphQLToProtobufConverterTest {
+class GraphQLToProtobufConverterTest {
     private static final Path workingDirectory = Path.of("src", "test", "resources", "schema", "graphql");
 
     private final GraphQLToProtobufConverter graphQLToProtobufConverter =

--- a/manager/src/test/java/com/bakdata/quick/manager/k8s/KubernetesTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/k8s/KubernetesTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
  * Provides k8s integration for tests.
  */
 @Getter
-public class KubernetesTest {
+public abstract class KubernetesTest {
     public static final String NAMESPACE = "test";
     public static final String DOCKER_REGISTRY = "registry.hub.docker.com";
     public static final String DEFAULT_IMAGE_TAG = "latest";

--- a/manager/src/test/java/com/bakdata/quick/manager/k8s/cluster/TopicRegistryInitializerTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/k8s/cluster/TopicRegistryInitializerTest.java
@@ -181,9 +181,10 @@ class TopicRegistryInitializerTest {
         final TopicRegistryInitializer
             topicRegistryInitializer = new TopicRegistryInitializer(kafkaConfig, registryConfig, this.mock);
 
-        assertThatExceptionOfType(InternalErrorException.class).isThrownBy(() -> {
-            topicRegistryInitializer.onStartUp(new StartupEvent(this.applicationContext));
-        });
+        final StartupEvent event = new StartupEvent(this.applicationContext);
+        assertThatExceptionOfType(InternalErrorException.class).isThrownBy(() ->
+            topicRegistryInitializer.onStartUp(event)
+        );
     }
 
     @Test
@@ -197,9 +198,10 @@ class TopicRegistryInitializerTest {
         final TopicRegistryInitializer
             topicRegistryInitializer = new TopicRegistryInitializer(kafkaConfig, registryConfig, this.mock);
 
-        assertThatExceptionOfType(InternalErrorException.class).isThrownBy(() -> {
-            topicRegistryInitializer.onStartUp(new StartupEvent(this.applicationContext));
-        });
+        final StartupEvent startupEvent = new StartupEvent(this.applicationContext);
+        assertThatExceptionOfType(InternalErrorException.class).isThrownBy(() ->
+            topicRegistryInitializer.onStartUp(startupEvent)
+        );
     }
 
     private void successfulMock() {

--- a/manager/src/test/java/com/bakdata/quick/manager/security/ApiKeyTest.java
+++ b/manager/src/test/java/com/bakdata/quick/manager/security/ApiKeyTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.when;
 import com.bakdata.quick.manager.topic.TopicService;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -48,12 +50,9 @@ class ApiKeyTest {
 
     @Test
     void shouldUnauthorizedWhenApiKeyNotSetInHeader() {
-        final Throwable exception = assertThrows(
-            HttpClientResponseException.class,
-            () -> this.client
-                .toBlocking()
-                .exchange(DELETE(SECURE_PATH))
-        );
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final MutableHttpRequest<?> request = DELETE(SECURE_PATH);
+        final Throwable exception = assertThrows(HttpClientResponseException.class, () -> httpClient.exchange(request));
         assertThat(exception.getMessage()).isEqualTo("Unauthorized");
     }
 
@@ -83,23 +82,17 @@ class ApiKeyTest {
 
     @Test
     void shouldUnauthorizedWhenApiKeyIsNotValid() {
-        final Throwable exception = assertThrows(
-            HttpClientResponseException.class,
-            () -> this.client
-                .toBlocking()
-                .exchange(DELETE(SECURE_PATH).header("X-API-Key", "wrong_key"))
-        );
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final MutableHttpRequest<?> request = DELETE(SECURE_PATH).header("X-API-Key", "wrong_key");
+        final Throwable exception = assertThrows(HttpClientResponseException.class, () -> httpClient.exchange(request));
         assertThat(exception.getMessage()).isEqualTo("Unauthorized");
     }
 
     @Test
     void shouldUnauthorizedWhenApiKeyHeaderKeyIsWrong() {
-        final Throwable exception = assertThrows(
-            HttpClientResponseException.class,
-            () -> this.client
-                .toBlocking()
-                .exchange(DELETE(SECURE_PATH).header("WRONG-API-Key", "test_key"))
-        );
+        final BlockingHttpClient httpClient = this.client.toBlocking();
+        final MutableHttpRequest<?> request = DELETE(SECURE_PATH).header("WRONG-API-Key", "test_key");
+        final Throwable exception = assertThrows(HttpClientResponseException.class, () -> httpClient.exchange(request));
         assertThat(exception.getMessage()).isEqualTo("Unauthorized");
     }
 

--- a/mirror/src/main/java/com/bakdata/quick/mirror/MirrorProcessor.java
+++ b/mirror/src/main/java/com/bakdata/quick/mirror/MirrorProcessor.java
@@ -57,5 +57,6 @@ public class MirrorProcessor<K, V> implements Processor<K, V> {
 
     @Override
     public void close() {
+        // No resources to close
     }
 }

--- a/mirror/src/main/java/com/bakdata/quick/mirror/retention/RetentionMirrorProcessor.java
+++ b/mirror/src/main/java/com/bakdata/quick/mirror/retention/RetentionMirrorProcessor.java
@@ -85,6 +85,6 @@ public class RetentionMirrorProcessor<K, V> implements Processor<K, V> {
 
     @Override
     public void close() {
-
+        // No resources to close
     }
 }

--- a/mirror/src/main/java/com/bakdata/quick/mirror/service/KafkaQueryService.java
+++ b/mirror/src/main/java/com/bakdata/quick/mirror/service/KafkaQueryService.java
@@ -147,10 +147,10 @@ public class KafkaQueryService<K, V> implements QueryService<V> {
     private V fetch(final HostInfo replicaHostInfo, final K key) {
         final String host = String.format("%s:%s", replicaHostInfo.host(), replicaHostInfo.port());
         final MirrorHost mirrorHost = new MirrorHost(host, MirrorConfig.directAccess());
-        final DefaultMirrorClient<K, V> client =
+        final DefaultMirrorClient<K, V> mirrorClient =
             new DefaultMirrorClient<>(mirrorHost, this.client, this.valueResolver);
         // TODO: don't bother deserializing
-        final V value = client.fetchValue(key);
+        final V value = mirrorClient.fetchValue(key);
 
         if (value == null) {
             throw new NotFoundException("Key not found");

--- a/mirror/src/main/java/com/bakdata/quick/mirror/service/QueryService.java
+++ b/mirror/src/main/java/com/bakdata/quick/mirror/service/QueryService.java
@@ -17,7 +17,6 @@
 package com.bakdata.quick.mirror.service;
 
 import com.bakdata.quick.common.api.model.mirror.MirrorValue;
-import io.reactivex.Flowable;
 import io.reactivex.Single;
 import java.util.List;
 

--- a/mirror/src/main/java/com/bakdata/quick/mirror/service/QueryServiceContext.java
+++ b/mirror/src/main/java/com/bakdata/quick/mirror/service/QueryServiceContext.java
@@ -16,8 +16,6 @@
 
 package com.bakdata.quick.mirror.service;
 
-import com.bakdata.quick.common.type.QuickTopicData;
-import lombok.Data;
 import lombok.Value;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.state.HostInfo;


### PR DESCRIPTION
This resolves a couple of sonar lint issues, mostly:
- multiple method calls in `assertThrows()`
- returning wildcards
- unused imports
- correct assertions