### PR TITLE
Remove required avro namespace from Helm chart

### DIFF
--- a/deployment/helm/quick/templates/quick-config.yaml
+++ b/deployment/helm/quick/templates/quick-config.yaml
@@ -8,7 +8,6 @@ metadata:
 data:
   QUICK_DOCKER_REGISTRY: {{ .Values.image.repository }}
   QUICK_SERVICE_INGEST: {{ .Values.ingest.name }}
-  QUICK_AVRO_NAMESPACE: {{ .Values.avro.namespace}}
   {{- if .Values.ingress.host }}
   QUICK_INGRESS_HOST: {{ .Values.ingress.host }}
   {{- end }}

--- a/deployment/helm/quick/values.yaml
+++ b/deployment/helm/quick/values.yaml
@@ -3,9 +3,6 @@ image:
   tag: ""
   pullPolicy: "Always"
 
-avro:
-  namespace: ""
-
 ingress:
   ssl: true
   entrypoint: "websecure"
@@ -35,3 +32,4 @@ quickConfig:
   QUICK_TOPIC_REGISTRY_PARTITIONS: "3"
   QUICK_TOPIC_REGISTRY_REPLICATION_FACTOR: "1"
   QUICK_SCHEMA_FORMAT: "Avro"
+  QUICK_SCHEMA_AVRO_NAMESPACE: ""

--- a/docs/docs/user/reference/helm-chart.md
+++ b/docs/docs/user/reference/helm-chart.md
@@ -1,6 +1,7 @@
 # Quick Helm chart
 
 Below you can find the default `value.yaml` of Quick's Helm chart.
+
 ```yaml
 image:
   # The base repository of the images
@@ -57,5 +58,8 @@ quickConfig:
   QUICK_SCHEMA_FORMAT: "Avro"
   # The namespace used for created avro namespaces
   # see https://avro.apache.org/docs/current/spec.html
-  QUICK_SCHEMA_AVRO_FORMAT: ""
+  QUICK_SCHEMA_AVRO_NAMESPACE: ""
+  # For Protobuf
+  # QUICK_SCHEMA_FORMAT: "Protobuf"
+  # QUICK_SCHEMA_PROTOBUF_PACKAGE: ""
 ```

--- a/docs/docs/user/reference/helm-chart.md
+++ b/docs/docs/user/reference/helm-chart.md
@@ -10,11 +10,6 @@ image:
   # The image pull policy of manager and ingest service
   pullPolicy: "Always"
 
-avro:
-  # The namespace used for created avro namespaces
-  # see https://avro.apache.org/docs/current/spec.html
-  namespace: ""
-
 # These configurations apply to both the helm chart ingresses and the gateway ingresses
 ingress:
   # Whether the ingress uses ssl
@@ -60,4 +55,7 @@ quickConfig:
   QUICK_TOPIC_REGISTRY_PARTITIONS: "3"
   QUICK_TOPIC_REGISTRY_REPLICATION_FACTOR: "1"
   QUICK_SCHEMA_FORMAT: "Avro"
+  # The namespace used for created avro namespaces
+  # see https://avro.apache.org/docs/current/spec.html
+  QUICK_SCHEMA_AVRO_FORMAT: ""
 ```


### PR DESCRIPTION
This removes "avro.namespace" from the Helm chart, as it is no longer required